### PR TITLE
create_object_navlist_iql - switched from post to get

### DIFF
--- a/atlassian/insight.py
+++ b/atlassian/insight.py
@@ -452,7 +452,7 @@ class Insight(AtlassianRestAPI):
         if object_id is not None:
             data["objectId"] = object_id
         url = self.url_joiner(self.api_root, "iql/objects")
-        return self.post(url, data=data)
+        return self.get(url, data=data)
 
     # Objectconnectedtickets
     def get_object_connected_tickets(self, object_id):


### PR DESCRIPTION
According to Atlassian
https://docs.atlassian.com/assets/REST/9.1.16/#iql-findObjects GET should be used and not POST.

A local test showed a 405 with POST and a correct result with GET.